### PR TITLE
Start using Grand Unified Receipt format and remove usage of deprecat…

### DIFF
--- a/InAppUtils/InAppUtils.m
+++ b/InAppUtils/InAppUtils.m
@@ -194,12 +194,23 @@ RCT_EXPORT_METHOD(canMakePayments: (RCTResponseSenderBlock)callback)
 
 RCT_EXPORT_METHOD(receiptData:(RCTResponseSenderBlock)callback)
 {
+    NSString *receipt = [self grandUnifiedReceipt];
+    if (receipt == nil) {
+        callback(@[@"not_available"]);
+    } else {
+        callback(@[[NSNull null], receipt]);
+    }
+}
+
+// Fetch Grand Unified Receipt
+- (NSString *)grandUnifiedReceipt
+{
     NSURL *receiptUrl = [[NSBundle mainBundle] appStoreReceiptURL];
     NSData *receiptData = [NSData dataWithContentsOfURL:receiptUrl];
     if (!receiptData) {
-      callback(@[@"not_available"]);
+        return nil;
     } else {
-      callback(@[[NSNull null], [receiptData base64EncodedStringWithOptions:0]]);
+        return [receiptData base64EncodedStringWithOptions:0];
     }
 }
 
@@ -220,7 +231,7 @@ RCT_EXPORT_METHOD(receiptData:(RCTResponseSenderBlock)callback)
                                       @"currencyCode": [item.priceLocale objectForKey:NSLocaleCurrencyCode],
                                       @"priceString": item.priceString,
                                       @"countryCode": [item.priceLocale objectForKey: NSLocaleCountryCode],
-                                      @"downloadable": item.downloadable ? @"true" : @"false" ,
+                                      @"downloadable": item.isDownloadable ? @"true" : @"false" ,
                                       @"description": item.localizedDescription ? item.localizedDescription : @"",
                                       @"title": item.localizedTitle ? item.localizedTitle : @"",
                                       };
@@ -248,7 +259,7 @@ RCT_EXPORT_METHOD(receiptData:(RCTResponseSenderBlock)callback)
                                                                                      @"transactionDate": @(transaction.transactionDate.timeIntervalSince1970 * 1000),
                                                                                      @"transactionIdentifier": transaction.transactionIdentifier,
                                                                                      @"productIdentifier": transaction.payment.productIdentifier,
-                                                                                     @"transactionReceipt": [[transaction transactionReceipt] base64EncodedStringWithOptions:0]
+                                                                                     @"transactionReceipt": [self grandUnifiedReceipt]
                                                                                      }];
     // originalTransaction is available for restore purchase and purchase of cancelled/expired subscriptions
     SKPaymentTransaction *originalTransaction = transaction.originalTransaction;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "react-native-in-app-utils",
-  "version": "6.0.1",
+  "name": "@nfl/react-native-in-app-utils",
+  "version": "6.1.0",
   "description": "A react-native wrapper for handling in-app payments.",
   "author": {
     "name": "Chirag Jain",


### PR DESCRIPTION
## Use Grand Unified Receipt format

Change the piece of code that fetches the transaction receipt so it'll use the Grand Unified Receipt format.

### Test:

1. On `nfl-rn` repo, checkout the branch `enable-in-app-debug-testing` (That enables In-App Debug testing)
1. Integrate this branch on `NFLMobile` app
1. Make sure you're observing callbacks from In-App purchases
1. Build `NFLMobile` and make a purchase